### PR TITLE
feat(items): add Item model and ItemsRepository interface

### DIFF
--- a/app/src/androidTest/java/com/android/ootd/model/items/ItemsRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/ootd/model/items/ItemsRepositoryFirestoreTest.kt
@@ -1,0 +1,194 @@
+package com.android.ootd.model.items
+
+import android.net.Uri
+import android.util.Log
+import com.android.ootd.model.ITEMS_COLLECTION
+import com.android.ootd.model.Item
+import com.android.ootd.model.ItemsRepositoryProvider.repository
+import com.android.ootd.model.Material
+import com.android.ootd.utils.FirebaseEmulator
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class ItemsRepositoryFirestoreTest() {
+
+  @Before
+  fun setup() {
+    FirebaseEmulator
+  }
+
+  val item1 =
+      Item(
+          uuid = "0",
+          image = Uri.parse("https://example.com/image1.jpg"),
+          category = "clothes",
+          type = "t-shirt",
+          brand = "Mango",
+          price = 0.0,
+          material = listOf(),
+          link = "https://example.com/item1")
+
+  val item2 =
+      Item(
+          uuid = "1",
+          image = Uri.parse("https://example.com/image1.jpg"),
+          category = "shoes",
+          type = "high heels",
+          brand = "Zara",
+          price = 30.0,
+          material = listOf(),
+          link = "https://example.com/item2")
+
+  val item3 =
+      Item(
+          uuid = "2",
+          image = Uri.parse("https://example.com/image1.jpg"),
+          category = "bags",
+          type = "handbag",
+          brand = "Vakko",
+          price = 0.0,
+          material = listOf(),
+          link = "https://example.com/item3")
+
+  val item4 =
+      Item(
+          uuid = "3",
+          image = Uri.parse("https://example.com/image1.jpg"),
+          category = "accessories",
+          type = "sunglasses",
+          brand = "Ray-Ban",
+          price = 100.0,
+          material =
+              listOf(
+                  Material(name = "Plastic", percentage = 80.0),
+                  Material(name = "Metal", percentage = 20.0)),
+          link = "https://example.com/item4")
+
+  suspend fun countItems(): Int {
+    return Firebase.firestore.collection(ITEMS_COLLECTION).get().await().size()
+  }
+
+  @Test
+  fun getNewItemIdReturnsUniqueIDs() = runTest {
+    val numberIDs = 100
+    val uids = (0 until 100).toSet<Int>().map { repository.getNewItemId() }.toSet()
+    assertEquals(uids.size, numberIDs)
+  }
+
+  @Test
+  fun addItemWithTheCorrectID() = runTest {
+    repository.addItem(item1)
+    val snapshot =
+        Firebase.firestore.collection(ITEMS_COLLECTION).document(item1.uuid).get().await()
+
+    Log.d("FirestoreTest", "Firestore stored document: ${snapshot.data}")
+    assertEquals(1, countItems())
+    val storedTodo = repository.getItemById(item1.uuid)
+    assertEquals(storedTodo, item1)
+  }
+
+  @Test
+  fun canAddItemToRepository() = runTest {
+    repository.addItem(item1)
+    assertEquals(1, countItems())
+    val todos = repository.getAllItems()
+
+    assertEquals(1, todos.size)
+    val expectedTodo = item1.copy(uuid = "None", link = "None")
+    val storedTodo = todos.first().copy(uuid = expectedTodo.uuid, link = expectedTodo.link)
+
+    assertEquals(expectedTodo, storedTodo)
+  }
+
+  @Test
+  fun retrieveItemById() = runTest {
+    repository.addItem(item1)
+    repository.addItem(item2)
+    repository.addItem(item3)
+    assertEquals(3, countItems())
+    val storedTodo = repository.getItemById(item3.uuid)
+    assertEquals(storedTodo, item3)
+
+    val storedTodo2 = repository.getItemById(item2.uuid)
+    assertEquals(storedTodo2, item2)
+  }
+
+  @Test
+  fun checkUidsAreUniqueInTheCollection() = runTest {
+    val uid = "duplicate"
+    val item1Modified = item1.copy(uuid = uid)
+    val itemDuplicatedUID = item2.copy(uuid = uid)
+    // Depending on your implementation, adding a Item with an existing UID
+    // might not be permitted
+    runCatching {
+      repository.addItem(item1Modified)
+      repository.addItem(itemDuplicatedUID)
+    }
+
+    assertEquals(1, countItems())
+
+    val items = repository.getAllItems()
+    assertEquals(items.size, 1)
+    val storedItem = items.first()
+    assertEquals(storedItem.uuid, uid)
+  }
+
+  @Test
+  fun deleteItemById() = runTest {
+    repository.addItem(item1)
+    repository.addItem(item2)
+    repository.addItem(item3)
+    assertEquals(3, countItems())
+
+    repository.deleteItem(item2.uuid)
+    assertEquals(2, countItems())
+    val items = repository.getAllItems()
+    assertEquals(items.size, 2)
+    assert(!items.contains(item2))
+
+    // Deleting an item that does not exist should not throw
+    repository.deleteItem(item2.uuid)
+    assertEquals(2, countItems())
+  }
+
+  @Test
+  fun editItemById() = runTest {
+    repository.addItem(item1)
+    assertEquals(1, countItems())
+
+    val newItem =
+        item1.copy(
+            type = "shirt",
+            brand = "H&M",
+            price = 20.0,
+            material = listOf(Material(name = "Cotton", percentage = 100.0)))
+    repository.editItem(item1.uuid, newItem)
+    assertEquals(1, countItems())
+    val items = repository.getAllItems()
+    assertEquals(items.size, 1)
+    val storedItem = items.first()
+    assertEquals(storedItem, newItem)
+
+    // Editing an item that does not exist should throw
+    val nonExistingItem = item2.copy(uuid = "nonExisting")
+    var didThrow = false
+    try {
+      repository.editItem(nonExistingItem.uuid, nonExistingItem)
+    } catch (e: Exception) {
+      didThrow = true
+    }
+    assert(didThrow)
+    assertEquals(1, countItems())
+  }
+
+  @After
+  fun tearDown() {
+    FirebaseEmulator.clearFirestoreEmulator()
+  }
+}

--- a/app/src/main/java/com/android/ootd/model/Item.kt
+++ b/app/src/main/java/com/android/ootd/model/Item.kt
@@ -1,0 +1,14 @@
+package com.android.ootd.model
+
+import android.net.Uri
+
+data class Item(
+    val itemId: String,
+    val image : Uri,
+    val category: String,
+    val type: String,
+    val brand : String,
+    val price: Double,
+    val material: String,
+    val link: String,
+)

--- a/app/src/main/java/com/android/ootd/model/Item.kt
+++ b/app/src/main/java/com/android/ootd/model/Item.kt
@@ -4,10 +4,10 @@ import android.net.Uri
 
 data class Item(
     val itemId: String,
-    val image : Uri,
+    val image: Uri,
     val category: String,
     val type: String,
-    val brand : String,
+    val brand: String,
     val price: Double,
     val material: String,
     val link: String,

--- a/app/src/main/java/com/android/ootd/model/Item.kt
+++ b/app/src/main/java/com/android/ootd/model/Item.kt
@@ -3,12 +3,14 @@ package com.android.ootd.model
 import android.net.Uri
 
 data class Item(
-    val itemUUID: String,
+    val uuid: String,
     val image: Uri,
     val category: String,
     val type: String,
     val brand: String,
     val price: Double,
-    val material: String,
+    val material: List<Material>,
     val link: String,
 )
+
+data class Material(val name: String = "", val percentage: Double = 0.0)

--- a/app/src/main/java/com/android/ootd/model/Item.kt
+++ b/app/src/main/java/com/android/ootd/model/Item.kt
@@ -3,7 +3,7 @@ package com.android.ootd.model
 import android.net.Uri
 
 data class Item(
-    val itemId: String,
+    val itemUUID: String,
     val image: Uri,
     val category: String,
     val type: String,

--- a/app/src/main/java/com/android/ootd/model/ItemsRepository.kt
+++ b/app/src/main/java/com/android/ootd/model/ItemsRepository.kt
@@ -1,50 +1,48 @@
 package com.android.ootd.model
 
-/**
- *  Repository class that handles data operations for items.
- */
+/** Repository class that handles data operations for items. */
 interface ItemsRepository {
 
-    /** Generates and returns a new unique identifier for a Clothing item. */
-    fun getNewItemId(): String
+  /** Generates and returns a new unique identifier for a Clothing item. */
+  fun getNewItemId(): String
 
-    /**
-     * Gets the all the items from the repository
-     *
-     * @return A list of all items.
-     * */
-    suspend fun getAllItems(): List<Item>
+  /**
+   * Gets the all the items from the repository
+   *
+   * @return A list of all items.
+   */
+  suspend fun getAllItems(): List<Item>
 
-    /**
-     * Gets a specific item by its unique identifier.
-     *
-     * @param id The unique identifier of the item to retrieve.
-     * @return The item with the specified identifier, or null if not found.
-     * */
-    suspend fun getItemById(id: Long): Item?
+  /**
+   * Gets a specific item by its unique identifier.
+   *
+   * @param id The unique identifier of the item to retrieve.
+   * @return The item with the specified identifier, or null if not found.
+   */
+  suspend fun getItemById(id: Long): Item?
 
-    /**
-     * Adds a new item to the repository.
-     *
-     * @param item The item to add.
-     * @return The unique identifier of the newly added item.
-     * */
-    suspend fun addItem(item: Item): Long
+  /**
+   * Adds a new item to the repository.
+   *
+   * @param item The item to add.
+   * @return The unique identifier of the newly added item.
+   */
+  suspend fun addItem(item: Item): Long
 
-    /**
-     * Edits an existing item in the repository.
-     *
-     * @param itemID The unique identifier of the item to edit.
-     * @param newItem The item with updated information.
-     * @throws Exception if the item is not found.
-     * */
-    suspend fun edit(itemID: String, newItem: Item)
+  /**
+   * Edits an existing item in the repository.
+   *
+   * @param itemID The unique identifier of the item to edit.
+   * @param newItem The item with updated information.
+   * @throws Exception if the item is not found.
+   */
+  suspend fun edit(itemID: String, newItem: Item)
 
-    /**
-     * Deletes an item from the repository by its unique identifier.
-     *
-     * @param id The unique identifier of the item to delete.
-     * @throws Exception if the Clothing item is not found.
-     * */
-    suspend fun deleteItem(id: String)
+  /**
+   * Deletes an item from the repository by its unique identifier.
+   *
+   * @param id The unique identifier of the item to delete.
+   * @throws Exception if the Clothing item is not found.
+   */
+  suspend fun deleteItem(id: String)
 }

--- a/app/src/main/java/com/android/ootd/model/ItemsRepository.kt
+++ b/app/src/main/java/com/android/ootd/model/ItemsRepository.kt
@@ -7,7 +7,7 @@ interface ItemsRepository {
   fun getNewItemId(): String
 
   /**
-   * Gets the all the items from the repository
+   * Gets all the items from the repository
    *
    * @return A list of all items.
    */
@@ -16,33 +16,33 @@ interface ItemsRepository {
   /**
    * Gets a specific item by its unique identifier.
    *
-   * @param id The unique identifier of the item to retrieve.
+   * @param uuid The unique identifier of the item to retrieve.
    * @return The item with the specified identifier, or null if not found.
+   * @throws Exception if the item is not found.
    */
-  suspend fun getItemById(id: Long): Item?
+  suspend fun getItemById(uuid: String): Item
 
   /**
    * Adds a new item to the repository.
    *
    * @param item The item to add.
-   * @return The unique identifier of the newly added item.
    */
-  suspend fun addItem(item: Item): Long
+  suspend fun addItem(item: Item)
 
   /**
    * Edits an existing item in the repository.
    *
-   * @param itemID The unique identifier of the item to edit.
+   * @param itemUUID The unique identifier of the item to edit.
    * @param newItem The item with updated information.
    * @throws Exception if the item is not found.
    */
-  suspend fun edit(itemID: String, newItem: Item)
+  suspend fun editItem(itemUUID: String, newItem: Item)
 
   /**
    * Deletes an item from the repository by its unique identifier.
    *
-   * @param id The unique identifier of the item to delete.
+   * @param uuid The unique identifier of the item to delete.
    * @throws Exception if the Clothing item is not found.
    */
-  suspend fun deleteItem(id: String)
+  suspend fun deleteItem(uuid: String)
 }

--- a/app/src/main/java/com/android/ootd/model/ItemsRepository.kt
+++ b/app/src/main/java/com/android/ootd/model/ItemsRepository.kt
@@ -1,0 +1,50 @@
+package com.android.ootd.model
+
+/**
+ *  Repository class that handles data operations for items.
+ */
+interface ItemsRepository {
+
+    /** Generates and returns a new unique identifier for a Clothing item. */
+    fun getNewItemId(): String
+
+    /**
+     * Gets the all the items from the repository
+     *
+     * @return A list of all items.
+     * */
+    suspend fun getAllItems(): List<Item>
+
+    /**
+     * Gets a specific item by its unique identifier.
+     *
+     * @param id The unique identifier of the item to retrieve.
+     * @return The item with the specified identifier, or null if not found.
+     * */
+    suspend fun getItemById(id: Long): Item?
+
+    /**
+     * Adds a new item to the repository.
+     *
+     * @param item The item to add.
+     * @return The unique identifier of the newly added item.
+     * */
+    suspend fun addItem(item: Item): Long
+
+    /**
+     * Edits an existing item in the repository.
+     *
+     * @param itemID The unique identifier of the item to edit.
+     * @param newItem The item with updated information.
+     * @throws Exception if the item is not found.
+     * */
+    suspend fun edit(itemID: String, newItem: Item)
+
+    /**
+     * Deletes an item from the repository by its unique identifier.
+     *
+     * @param id The unique identifier of the item to delete.
+     * @throws Exception if the Clothing item is not found.
+     * */
+    suspend fun deleteItem(id: String)
+}

--- a/app/src/main/java/com/android/ootd/model/ItemsRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/ootd/model/ItemsRepositoryFirestore.kt
@@ -1,7 +1,7 @@
 package com.android.ootd.model
 
-import android.net.Uri
 import android.util.Log
+import androidx.core.net.toUri
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
@@ -42,12 +42,12 @@ private fun mapToItem(doc: DocumentSnapshot): Item? {
   return try {
     val uuid = doc.getString("uuid") ?: return null
     val image = doc.getString("image") ?: return null
-    val imageUri = Uri.parse(image)
+    val imageUri = image.toUri()
     val category = doc.getString("category") ?: return null
     val type = doc.getString("type") ?: return null
     val brand = doc.getString("brand") ?: return null
-    val price = doc.get("price") ?: return null
-    val link = doc.get("link") ?: return null
+    val price = doc.getDouble("price") ?: return null
+    val link = doc.getString("link") ?: return null
 
     val materialList = doc.get("material") as? List<*>
     val material =
@@ -65,9 +65,9 @@ private fun mapToItem(doc: DocumentSnapshot): Item? {
         category = category,
         type = type,
         brand = brand,
-        price = price as Double,
+        price = price,
         material = material,
-        link = link as String,
+        link = link,
     )
   } catch (e: Exception) {
     Log.e("ItemsRepositoryFirestore", "Error converting document ${doc.id} to Item", e)

--- a/app/src/main/java/com/android/ootd/model/ItemsRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/ootd/model/ItemsRepositoryFirestore.kt
@@ -1,0 +1,76 @@
+package com.android.ootd.model
+
+import android.net.Uri
+import android.util.Log
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+const val ITEMS_COLLECTION = "items"
+
+class ItemsRepositoryFirestore(private val db: FirebaseFirestore) : ItemsRepository {
+  override fun getNewItemId(): String {
+    return db.collection(ITEMS_COLLECTION).document().id
+  }
+
+  override suspend fun getAllItems(): List<Item> {
+    val snapshot = db.collection(ITEMS_COLLECTION).get().await()
+    return snapshot.mapNotNull { mapToItem(it) }
+  }
+
+  override suspend fun getItemById(uuid: String): Item {
+    val doc = db.collection(ITEMS_COLLECTION).document(uuid).get().await()
+    return mapToItem(doc) ?: throw Exception("ItemsRepositoryFirestore: Item not found")
+  }
+
+  override suspend fun addItem(item: Item) {
+    db.collection(ITEMS_COLLECTION).document(item.uuid).set(item).await()
+  }
+
+  override suspend fun editItem(itemUUID: String, newItem: Item) {
+    val doc = db.collection(ITEMS_COLLECTION).document(itemUUID).get().await()
+    if (!doc.exists()) throw Exception("Item $itemUUID not found")
+    db.collection(ITEMS_COLLECTION).document(itemUUID).set(newItem).await()
+  }
+
+  override suspend fun deleteItem(uuid: String) {
+    db.collection(ITEMS_COLLECTION).document(uuid).delete().await()
+  }
+}
+
+private fun mapToItem(doc: DocumentSnapshot): Item? {
+  return try {
+    val uuid = doc.getString("uuid") ?: return null
+    val image = doc.getString("image") ?: return null
+    val imageUri = Uri.parse(image)
+    val category = doc.getString("category") ?: return null
+    val type = doc.getString("type") ?: return null
+    val brand = doc.getString("brand") ?: return null
+    val price = doc.get("price") ?: return null
+    val link = doc.get("link") ?: return null
+
+    val materialList = doc.get("material") as? List<*>
+    val material =
+        materialList?.mapNotNull { item ->
+          (item as? Map<*, *>)?.let {
+            Material(
+                name = it["name"] as? String ?: "",
+                percentage = (it["percentage"] as? Number)?.toDouble() ?: 0.0)
+          }
+        } ?: emptyList()
+
+    Item(
+        uuid = uuid,
+        image = imageUri,
+        category = category,
+        type = type,
+        brand = brand,
+        price = price as Double,
+        material = material,
+        link = link as String,
+    )
+  } catch (e: Exception) {
+    Log.e("ItemsRepositoryFirestore", "Error converting document ${doc.id} to Item", e)
+    null
+  }
+}

--- a/app/src/main/java/com/android/ootd/model/ItemsRepositoryProvider.kt
+++ b/app/src/main/java/com/android/ootd/model/ItemsRepositoryProvider.kt
@@ -1,0 +1,10 @@
+package com.android.ootd.model
+
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+
+object ItemsRepositoryProvider {
+  private val _repository: ItemsRepository by lazy { ItemsRepositoryFirestore(Firebase.firestore) }
+
+  var repository: ItemsRepository = _repository
+}


### PR DESCRIPTION
### Description 
This PR is the first step in implementing the Add Items feature.
It focuses on setting up the **data layer** required to store and manage item information in Firestore.

Specifically, it introduces : 
- `Item` data class - represents a clothing item and its details (ID, image, category, type, brand, price, material, link). 
- `ItemsRepository` interface - defines the contract for data operations on items. 

These components lay the foundation for Firestore integration and the upcoming `AddItemsScreen` logic. 

### Changes 
- Added `Items.kt`
- Added `ItemsRepository.kt`

### Testing 
- Successfully built the project using `./gradlew build`
- Verified that new files compile correctly 
- Formatting validated with `./gradlew ktfmtCheck`

### Related issues

Closes #17 



