### PR TITLE
fix(testing): Remove protobuf dependencies to fix testing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -242,3 +242,9 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         include("outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec")
     })
 }
+
+configurations.forEach { configuration ->
+    // Exclude protobuf-lite from all configurations
+    // This fixes a fatal exception for tests interacting with Cloud Firestore
+    configuration.exclude("com.google.protobuf", "protobuf-lite")
+}


### PR DESCRIPTION
As the comment from the bootcamp says, by removing protobuf, we are able to let the tests interact with Cloud Firestore.