### PR TITLE
feat(ui): implement Add Items screen with image upload and form valid…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -157,7 +157,8 @@ dependencies {
     implementation(libs.compose.ui.graphics)
     // Material Design 3
     implementation(libs.compose.material3)
-    // Integration with activities
+
+    implementation("io.coil-kt:coil-compose:2.6.0")    // Integration with activities
     implementation(libs.compose.activity)
     // Integration with ViewModels
     implementation(libs.compose.viewmodel)

--- a/app/src/main/java/com/android/ootd/ui/post/AddItemsScreen.kt
+++ b/app/src/main/java/com/android/ootd/ui/post/AddItemsScreen.kt
@@ -1,0 +1,213 @@
+package com.android.ootd.ui.post
+
+import android.net.Uri
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import java.io.File
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddItemsScreen(addItemsViewModel: AddItemsViewModel = viewModel()) {
+
+  val itemsUIState by addItemsViewModel.uiState.collectAsState()
+  val errorMsg = itemsUIState.errorMessage
+
+  var expanded by remember { mutableStateOf(false) }
+  var cameraUri by remember { mutableStateOf<Uri?>(null) }
+
+  val galleryLauncher =
+      rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) { uri: Uri?
+        ->
+        uri?.let { addItemsViewModel.setPhoto(it) }
+      }
+
+  val cameraLauncher =
+      rememberLauncherForActivityResult(contract = ActivityResultContracts.TakePicture()) { success
+        ->
+        if (success && cameraUri != null) addItemsViewModel.setPhoto(cameraUri!!)
+      }
+
+  val context = LocalContext.current
+  LaunchedEffect(errorMsg) {
+    if (errorMsg != null) {
+      // For example, using Toast:
+      Toast.makeText(context, errorMsg, Toast.LENGTH_SHORT).show()
+      addItemsViewModel.clearErrorMsg()
+    }
+  }
+
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = { Text("Add Items", style = MaterialTheme.typography.titleLarge) },
+            navigationIcon = {
+              IconButton(onClick = {}) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                    contentDescription = "Back")
+              }
+            })
+      },
+      content = { innerPadding ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(16.dp).padding(innerPadding),
+            verticalArrangement = Arrangement.spacedBy(8.dp)) {
+              Box(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .height(220.dp)
+                          .clip(RoundedCornerShape(16.dp))
+                          .background(
+                              MaterialTheme.colorScheme
+                                  .background), // light gray placeholder background
+                  contentAlignment = Alignment.Center) {
+                    if (itemsUIState.image != Uri.EMPTY) {
+                      // 🖼️ Show selected photo
+                      AsyncImage(
+                          model = itemsUIState.image,
+                          contentDescription = "Selected image",
+                          modifier = Modifier.fillMaxSize(),
+                          contentScale = ContentScale.Crop)
+                    } else {
+                      // ➕ Placeholder when no image
+                      Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = "Add photo",
+                            modifier = Modifier.size(48.dp))
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = "Tap to add a photo",
+                            style = MaterialTheme.typography.bodyMedium)
+                      }
+                    }
+                  }
+              Row(
+                  modifier = Modifier.fillMaxWidth(),
+                  horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(
+                        onClick = { galleryLauncher.launch("image/*") },
+                        modifier = Modifier.weight(1f)) {
+                          Text("Gallery")
+                        }
+                    Button(
+                        onClick = {
+                          val file = File(context.cacheDir, "${System.currentTimeMillis()}.jpg")
+                          val uri =
+                              FileProvider.getUriForFile(
+                                  context, "${context.packageName}.fileprovider", file)
+                          cameraUri = uri
+                          cameraLauncher.launch(uri)
+                        },
+                        modifier = Modifier.weight(1f)) {
+                          Text("Camera")
+                        }
+                  }
+
+              OutlinedTextField(
+                  value = itemsUIState.category,
+                  onValueChange = { addItemsViewModel.setCategory(it) },
+                  label = { Text("Category") },
+                  placeholder = { Text("e.g., Clothes") },
+                  modifier = Modifier.fillMaxWidth())
+
+              Box {
+                OutlinedTextField(
+                    value = itemsUIState.type,
+                    onValueChange = {
+                      addItemsViewModel.setType(it)
+                      addItemsViewModel.updateTypeSuggestions(it)
+                      expanded = true
+                    },
+                    label = { Text("Type") },
+                    modifier = Modifier.fillMaxWidth())
+                DropdownMenu(
+                    expanded = expanded && itemsUIState.suggestions.isNotEmpty(),
+                    onDismissRequest = { expanded = false },
+                    modifier = Modifier.fillMaxWidth()) {
+                      itemsUIState.suggestions.forEach { suggestion ->
+                        DropdownMenuItem(
+                            text = { Text(suggestion) },
+                            onClick = {
+                              addItemsViewModel.setType(suggestion)
+                              expanded = false
+                            })
+                      }
+                    }
+              }
+
+              OutlinedTextField(
+                  value = itemsUIState.brand,
+                  onValueChange = { addItemsViewModel.setBrand(it) },
+                  label = { Text("Brand") },
+                  modifier = Modifier.fillMaxWidth())
+
+              OutlinedTextField(
+                  value = if (itemsUIState.price == 0.0) "" else itemsUIState.price.toString(),
+                  onValueChange = {
+                    val price = it.toDoubleOrNull() ?: 0.0
+                    addItemsViewModel.setPrice(price)
+                  },
+                  label = { Text("Price") },
+                  placeholder = { Text("e.g., 49.99") },
+                  modifier = Modifier.fillMaxWidth())
+
+              OutlinedTextField(
+                  value = itemsUIState.link,
+                  onValueChange = { addItemsViewModel.setLink(it) },
+                  label = { Text("Link") },
+                  placeholder = { Text("e.g., https://zara.com") },
+                  modifier = Modifier.fillMaxWidth())
+
+              Button(
+                  onClick = { addItemsViewModel.canAddItems() },
+                  enabled = itemsUIState.image != Uri.EMPTY && itemsUIState.category.isNotEmpty(),
+                  modifier = Modifier.fillMaxWidth()) {
+                    Text("Add Item")
+                  }
+            }
+      })
+}

--- a/app/src/main/java/com/android/ootd/ui/post/AddItemsViewModel.kt
+++ b/app/src/main/java/com/android/ootd/ui/post/AddItemsViewModel.kt
@@ -1,0 +1,220 @@
+package com.android.ootd.ui.post
+
+import android.net.Uri
+import android.webkit.URLUtil.isValidUrl
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.android.ootd.model.Item
+import com.android.ootd.model.ItemsRepository
+import com.android.ootd.model.ItemsRepositoryProvider
+import com.android.ootd.model.Material
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * UI state for the AddItems screen. This state holds the data needed to create a new Clothing item.
+ */
+data class AddItemsUIState(
+    val image: Uri = Uri.EMPTY,
+    val category: String = "",
+    val type: String = "",
+    val brand: String = "",
+    val price: Double = 0.0,
+    val material: List<Material> = emptyList(),
+    val link: String = "",
+    val errorMessage: String? = null,
+    val invalidPhotoMsg: String? = null,
+    val invalidCategory: String? = null,
+    val suggestions: List<String> = emptyList(),
+) {
+  val isAddingValid: Boolean
+    get() =
+        invalidPhotoMsg == null &&
+            invalidCategory == null &&
+            image != Uri.EMPTY &&
+            category.isNotEmpty()
+}
+
+/**
+ * ViewModel for the AddItems screen. This ViewModel manages the state of input fields for the
+ * AddItems screen.
+ */
+open class AddItemsViewModel(
+    private val repository: ItemsRepository = ItemsRepositoryProvider.repository,
+) : ViewModel() {
+
+  private val _uiState = MutableStateFlow(AddItemsUIState())
+  open val uiState: StateFlow<AddItemsUIState> = _uiState.asStateFlow()
+
+  /** Clears the error message in the UI state. */
+  fun clearErrorMsg() {
+    _uiState.value = _uiState.value.copy(errorMessage = null)
+  }
+
+  fun setErrorMsg(msg: String) {
+    _uiState.value = _uiState.value.copy(errorMessage = msg)
+  }
+
+  fun canAddItems(): Boolean {
+    val state = _uiState.value
+    if (!state.isAddingValid) {
+      setErrorMsg("Please fill in all required fields.")
+      return false
+    }
+
+    if (!isValidUrl(state.link)) {
+      setErrorMsg("Please enter a valid URL.")
+      return false
+    }
+
+    addItemsToRepository(
+        Item(
+            uuid = repository.getNewItemId(),
+            image = state.image,
+            category = state.category,
+            type = state.type,
+            brand = state.brand,
+            price = state.price,
+            material = state.material,
+            link = state.link))
+    clearErrorMsg()
+    return true
+  }
+
+  fun addItemsToRepository(item: Item) {
+    viewModelScope.launch {
+      try {
+        repository.addItem(item)
+      } catch (e: Exception) {
+        setErrorMsg("Failed to add item: ${e.message}")
+      }
+    }
+  }
+
+  fun setPhoto(uri: Uri) {
+    _uiState.value =
+        _uiState.value.copy(
+            image = uri, invalidPhotoMsg = if (uri == Uri.EMPTY) "Please select a photo." else null)
+  }
+
+  fun setCategory(category: String) {
+    _uiState.value =
+        _uiState.value.copy(
+            category = category,
+            invalidCategory = if (category.isEmpty()) "Please select a category." else null)
+  }
+
+  fun setType(type: String) {
+    _uiState.value = _uiState.value.copy(type = type)
+  }
+
+  fun setBrand(brand: String) {
+    _uiState.value = _uiState.value.copy(brand = brand)
+  }
+
+  fun setPrice(price: Double) {
+    _uiState.value = _uiState.value.copy(price = price)
+  }
+
+  fun setMaterial(material: List<Material>) {
+    _uiState.value = _uiState.value.copy(material = material)
+  }
+
+  fun setLink(link: String) {
+    _uiState.value = _uiState.value.copy(link = link)
+  }
+
+  private val typeSuggestions =
+      mapOf(
+          "Clothing" to
+              listOf(
+                  "T-shirt",
+                  "Shirt",
+                  "Jeans",
+                  "Jacket",
+                  "Dress",
+                  "Skirt",
+                  "Shorts",
+                  "Sweater",
+                  "Coat",
+                  "Blouse",
+                  "Suit",
+                  "Hoodie",
+                  "Cardigan",
+                  "Pants",
+                  "Leggings",
+                  "Overalls",
+                  "Jumpsuit"),
+          "Shoes" to
+              listOf(
+                  "Sneakers",
+                  "Boots",
+                  "Sandals",
+                  "Heels",
+                  "Flats",
+                  "Loafers",
+                  "Oxfords",
+                  "Slippers",
+                  "Wedges",
+                  "Espadrilles",
+                  "Ballerinas",
+                  "Moccasins",
+                  "Sports Shoes"),
+          "Accessories" to
+              listOf(
+                  "Hat",
+                  "Scarf",
+                  "Belt",
+                  "Gloves",
+                  "Sunglasses",
+                  "Watch",
+                  "Bracelet",
+                  "Necklace",
+                  "Earrings",
+                  "Tie",
+                  "Beanie",
+                  "Cap "),
+          "Bags" to
+              listOf(
+                  "Backpack",
+                  "Handbag",
+                  "Tote",
+                  "Clutch",
+                  "Messenger Bag",
+                  "Duffel Bag",
+                  "Satchel",
+                  "Crossbody Bag",
+                  "Shopper",
+                  "Wallet"),
+      )
+
+  fun updateTypeSuggestions(input: String) {
+    val state = _uiState.value
+    // val currentCategory = state.category
+
+    val normalizeCategory =
+        when (state.category.trim().lowercase()) {
+          "clothes",
+          "clothing" -> "Clothing"
+          "shoe",
+          "shoes" -> "Shoes"
+          "bag",
+          "bags" -> "Bags"
+          "accessory",
+          "accessories" -> "Accessories"
+          else -> state.category
+        }
+    val allSuggestions = typeSuggestions[normalizeCategory] ?: emptyList()
+
+    val filtered =
+        if (input.isBlank()) {
+          allSuggestions
+        } else {
+          allSuggestions.filter { it.startsWith(input, ignoreCase = true) }
+        }
+
+    _uiState.value = state.copy(suggestions = filtered)
+  }
+}


### PR DESCRIPTION
**Description**

This PR continues the work from the issue #17, focusing on implementing a form version of the items where users can enter the details of the clothes they want to post.

Specifically, it contains:
 
- `AddItemsScreen` - the composable function that allows users to input what wore on that day 
- `AddItemsViewModel` - the class that manages form state, handles validation, and processes user input.

With these implementations, users can now view and fill in item details before posting their outfits.

**Related issues**

Closes #63 

**Testing Checklist**
- [ ]  The Add Items screen displays correctly in the UI navigation flow
- [ ] All input fields (type, brand, price, material, etc.) update ViewModel state correctly
- [ ] Form validation prevents submission when required fields are empty 
- [ ]  Error messages appear for invalid inputs (e.g. missing fields, invalid URLs)
- [ ]  Image upload from the gallery works as expected
- [ ]  Screen resets after successful submission (if implemented)