### PR TITLE
feat: implement pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+Compact Pull Request template for the OOTD repository.
+Sections: Summary, What, Why, Screenshots/Videos, Checklist.
+Authors should keep entries short and remove sections that don't apply.
+-->
+
+# Summary
+<!-- Summary of the change. -->
+
+
+# What
+<!-- Briefly list what changed, grouped by area below. Remove any subsection that doesn't apply. -->
+
+- UI
+  - Screens/components updated (which screens/components?)
+  - Layout or style changes (what was changed?)
+  - New assets/resources added (icons, drawables, colors)
+- ViewModel
+  - State changes or new state fields
+  - Business logic / repository / API interactions modified
+  - Navigation or side-effect changes
+- Documentation
+  - Kdoc comments added/updated
+  - External docs (README updates, wiki) updated
+- Tests
+  - Unit tests added/updated (describe what and where)
+  - Integration tests added/updated
+  - UI/automation tests added or updated
+
+
+# Why
+<!-- Motivation, links to issues, and any design decisions or trade-offs. -->
+
+
+# Screenshots / Videos
+<!-- Optional: add screenshots or animated GIFs to help reviewers. -->
+
+
+# Checklist
+- [ ] Tests: added or updated (unit/instrumented/automation) as appropriate
+- [ ] Documentation: README/usage/docs updated where relevant
+- [ ] Manual verification: app run and basic flows checked (list steps in "What")
+- [ ] ...
+- [ ] ...
+- [ ] ...
+
+<!-- Remove any checklist items that don't apply to this PR -->


### PR DESCRIPTION
## Summary
Introduce a compact and organized PR template to standardize contributions. The template includes sections for summary, detailed change breakdown, motivation, media, and a checklist.

## What
- Added `.github/PULL_REQUEST_TEMPLATE.md` with:
  - Bullet-pointed 'What' section for UI, ViewModel, Documentation, and Tests
  - Sub-bullets to guide authors on specific details to include
  - Checklist for tests, documentation, and manual verification

## Why
- Improves clarity and consistency in PRs
- Helps reviewers quickly understand changes and their impact
- Encourages contributors to verify and document their work

## Impact
- All future PRs will use the new template when opened via GitHub UI
- Easier review process and better documentation of changes
