### PR TITLE
fix(ci): streamline CI setup by reorganizing the tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,25 @@ jobs:
           echo '  \___/ \___/ |_| |___/   \___|___|'
           echo '                                   '
 
+      # Setup all tools in parallel-friendly order
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      # Install NodeJS early for Firebase CLI
+      - name: Setup NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       # Kernel-based Virtual Machine (KVM) is an open source virtualization technology built into Linux. Enabling it allows the Android emulator to run faster.
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-
-      - name: Setup JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
 
       # Caching is a very useful part of a CI, as a workflow is executed in a clean environment every time,
       # this means that one would need to re-download and re-process gradle files for every run. Which is very time consuming.
@@ -62,7 +69,49 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      # Cache the Emulator, if the cache does not hit, create the emulator
+      # Load google-services.json from the secrets to initiate the FireBase
+      - name: Decode secrets for FireBase
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+        run: |
+          if [ -n "$GOOGLE_SERVICES" ]; then
+            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          else
+            echo "::warning::GOOGLE_SERVICES secret is not set !"
+          fi
+
+      - name: Grant execute permission for gradlew
+        run: |
+          chmod +x ./gradlew
+
+      # Install Firebase CLI
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      # Check formatting FIRST - fail fast if code isn't formatted
+      - name: KTFmt Check
+        run: |
+          ./gradlew ktfmtCheck
+
+      # Start Firebase emulators in background while we build
+      - name: Start Firebase emulators for testing
+        run: |
+          if [ -e "firebase.json" ] && jq -e '.emulators' firebase.json >/dev/null; then
+            echo "Starting Firebase emulators for Firestore tests..."
+            firebase emulators:start --only auth,firestore --project demo-project &
+            sleep 10  # Give emulators time to start
+            echo "Firebase emulators started"
+          else
+            echo "Firebase emulators not configured, skipping emulator startup..."
+          fi
+
+      # Combine assemble and unit tests in single gradle invocation
+      - name: Build and Run Unit Tests
+        run: |
+          # To run the CI with debug information, add --info
+          ./gradlew assemble check lint --parallel --build-cache
+
+      # Cache the Emulator AFTER we know build succeeds, if the cache does not hit, create the emulator
       - name: AVD cache
         uses: actions/cache@v4
         id: avd-cache
@@ -84,61 +133,8 @@ jobs:
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
-      # Load google-services.json from the secrets to initiate the FireBase
-      - name: Decode secrets for FireBase
-        env:
-          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
-        run: |
-          if [ -n "$GOOGLE_SERVICES" ]; then
-            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
-          else
-            echo "::warning::GOOGLE_SERVICES secret is not set !"
-          fi
-
-      - name: Grant execute permission for gradlew
-        run: |
-          chmod +x ./gradlew
-
-      # Install NodeJS
-      - name: Setup NodeJS
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      # Install Firebase CLI
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools
-
-      - name: Start Firebase emulators for testing
-        run: |
-          if [ -e "firebase.json" ] && jq -e '.emulators' firebase.json >/dev/null; then
-            echo "Starting Firebase emulators for Firestore tests..."
-            firebase emulators:start --only auth,firestore --project demo-project &
-            sleep 10  # Give emulators time to start
-            echo "Firebase emulators started"
-          else
-            echo "Firebase emulators not configured, skipping emulator startup..."
-          fi
-
-      # Check formatting
-      - name: KTFmt Check
-        run: |
-          ./gradlew ktfmtCheck
-
-      # This step runs gradle commands to build the application
-      - name: Assemble
-        run: |
-          # To run the CI with debug information, add --info
-          ./gradlew assemble lint --parallel --build-cache
-
-      # Run Unit tests
-      - name: Run tests
-        run: |
-          # To run the CI with debug information, add --info
-          ./gradlew check --parallel --build-cache
-
       # Run connected tests on the emulator
-      - name: run tests
+      - name: Run Instrumented Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35


### PR DESCRIPTION
# Summary
Optimized CI workflow execution order to reduce run times, especially on failed builds, by implementing fail-fast strategies and eliminating redundant Gradle invocations.

# What
- Moved KTFmt check to run immediately after setup (fail-fast principle)
- Combined Gradle commands (`assemble`, `check`, `lint`) into single invocation
- Reordered NodeJS/Firebase setup to run earlier for better parallelization
- Deferred AVD cache/creation until after build succeeds
- Improved step naming for better clarity in GitHub Actions UI

# Why
- **Faster feedback on failures**: Formatting checks now in the first checks rather than later on in the pipeline
- **Reduced wasted time**: Don't set up emulator if build/unit tests fail
- **Eliminated redundancy**: Single Gradle invocation some time by avoiding daemon startup overhead
- **Better resource usage**: Expensive operations (emulator, instrumented tests) only run after cheap validations pass
- **Improved developer experience**: Quicker feedback loop when common errors occur

# Checklist
- [ ] Manual verification: does it runs faster ? : (Edit) it can't run faster because it does the same tasks but in a different order, but it should improve time taken to find a bug when working on a branch.
