### PR TITLE
Add rules test for firebase to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Firestore Security Rules tests
         run: |
           if [ ! -e "firebase.json" ]; then # Check if firebase.json exists
-            echo "Warning: 'firebase.json' file is missing. Check with the team to properly set up the Firebase
+            echo "Warning: 'firebase.json' file is missing. Check with the team to properly set up the Firebase"
             exit 0
           fi
           jq -e '.emulators' firebase.json >/dev/null || { # Check if emulators are configured


### PR DESCRIPTION
# Summary
Added a new task to the CI: it now runs the test for the firebase in the rules `firebase/firestore/firestore.rules` file.

# Why
The CI can run the tests to see if the we properly implemented the rules in the Firebase. It has fallbacks to let us know if we are missing a file in the repository that the CI need to use in order to run the tests.