### PR TITLE
fix(ui): Fix ui theme and also colors to be like Figma

### DIFF
--- a/app/src/main/java/com/android/ootd/ui/search/UserProfileCard.kt
+++ b/app/src/main/java/com/android/ootd/ui/search/UserProfileCard.kt
@@ -1,9 +1,10 @@
 package com.android.ootd.ui.search
 
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -15,6 +16,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
@@ -56,9 +58,12 @@ fun UserProfileCard(
   Card(
       modifier = modifier.testTag(UserProfileCardTestTags.PROFILE_CARD),
       shape = RoundedCornerShape(16.dp),
-      colors =
-          CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)) {
-        Column(modifier = Modifier.fillMaxSize().padding(24.dp)) {
+      colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondary)) {
+        Column(
+            modifier = Modifier.padding(start = 28.dp, top = 30.dp, end = 28.dp, bottom = 30.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
+            horizontalAlignment = Alignment.Start,
+        ) {
           Text(
               modifier =
                   Modifier.testTag(UserProfileCardTestTags.USERNAME_TEXT)
@@ -66,13 +71,16 @@ fun UserProfileCard(
               text = selectedUser?.username ?: "",
               fontSize = 32.sp,
               fontWeight = FontWeight.Bold,
-              color = MaterialTheme.colorScheme.onBackground,
+              color = MaterialTheme.colorScheme.onSecondaryContainer,
               maxLines = 1)
 
           Spacer(modifier = Modifier.width(16.dp))
 
           Button(
-              modifier = Modifier.testTag(UserProfileCardTestTags.USER_FOLLOW_BUTTON),
+              modifier =
+                  Modifier.width(128.dp)
+                      .height(48.dp)
+                      .testTag(UserProfileCardTestTags.USER_FOLLOW_BUTTON),
               onClick = { selectedUser?.let { onFollowClick(it) } },
               shape = RoundedCornerShape(12.dp),
               colors =

--- a/app/src/main/java/com/android/ootd/ui/search/UserSearchScreen.kt
+++ b/app/src/main/java/com/android/ootd/ui/search/UserSearchScreen.kt
@@ -8,12 +8,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.ootd.model.user.UserRepositoryInMemory
+import com.android.ootd.ui.theme.OOTDTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -22,21 +21,24 @@ fun UserSearchScreen(viewModel: UserSearchViewModel = viewModel()) {
 
   Column(
       modifier =
-          Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background).padding(16.dp)) {
+          Modifier.fillMaxSize()
+              .background(MaterialTheme.colorScheme.background)
+              .padding(vertical = 32.dp, horizontal = 20.dp)) {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-          IconButton(onClick = { /* Handle back */}) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
-                tint = MaterialTheme.colorScheme.primary)
-          }
+          IconButton(
+              modifier = Modifier.width(48.dp).height(48.dp), onClick = { /* Handle back */}) {
+                Icon(
+                    modifier = Modifier.width(48.dp).height(48.dp),
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = MaterialTheme.colorScheme.primary)
+              }
 
           Spacer(modifier = Modifier.weight(1f))
 
           Text(
               text = "OOTD",
-              fontSize = 24.sp,
-              fontWeight = FontWeight.Bold,
+              style = MaterialTheme.typography.headlineLarge,
               color = MaterialTheme.colorScheme.primary)
 
           Spacer(modifier = Modifier.weight(1f))
@@ -67,13 +69,12 @@ fun UserSearchScreen(viewModel: UserSearchViewModel = viewModel()) {
       }
 }
 
-@Preview(showBackground = true, showSystemUi = true)
+@Preview(showBackground = true)
 @Composable
 fun UserSearchScreenPreview() {
-  // Create a mock ViewModel or pass mock state directly
-  val mockViewModel =
-      UserSearchViewModel(
-          userRepository = UserRepositoryInMemory(),
-          overrideUser = true) // or however you initialize it
-  UserSearchScreen(viewModel = mockViewModel)
+  OOTDTheme {
+    val mockViewModel =
+        UserSearchViewModel(userRepository = UserRepositoryInMemory(), overrideUser = true)
+    UserSearchScreen(viewModel = mockViewModel)
+  }
 }

--- a/app/src/main/java/com/android/ootd/ui/search/UserSelectionField.kt
+++ b/app/src/main/java/com/android/ootd/ui/search/UserSelectionField.kt
@@ -34,7 +34,7 @@ fun UserSelectionField(
         imageVector = Icons.Default.Search,
         contentDescription = "Search",
         tint = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.size(40.dp))
+        modifier = Modifier.size(56.dp))
 
     Spacer(modifier = Modifier.width(8.dp))
 
@@ -42,7 +42,12 @@ fun UserSelectionField(
       OutlinedTextField(
           value = usernameText,
           onValueChange = { onUsernameTextChanged(it) },
-          placeholder = { Text("Username", color = MaterialTheme.colorScheme.onSurfaceVariant) },
+          placeholder = {
+            Text(
+                "Username",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodyMedium)
+          },
           trailingIcon = {
             if (usernameText.isNotEmpty()) {
               IconButton(onClick = { onUsernameTextChanged("") }) {
@@ -55,12 +60,15 @@ fun UserSelectionField(
           },
           colors =
               OutlinedTextFieldDefaults.colors(
-                  focusedBorderColor = MaterialTheme.colorScheme.outline,
-                  unfocusedBorderColor = MaterialTheme.colorScheme.primary,
-                  focusedContainerColor = MaterialTheme.colorScheme.surface,
-                  unfocusedContainerColor = MaterialTheme.colorScheme.surface),
+                  focusedBorderColor = MaterialTheme.colorScheme.primary,
+                  unfocusedBorderColor = MaterialTheme.colorScheme.secondary,
+                  focusedContainerColor = MaterialTheme.colorScheme.background,
+                  unfocusedContainerColor = MaterialTheme.colorScheme.background),
           shape = RoundedCornerShape(24.dp),
-          modifier = Modifier.fillMaxWidth().testTag(UserSelectionFieldTestTags.INPUT_USERNAME),
+          modifier =
+              Modifier.fillMaxWidth()
+                  .height(56.dp)
+                  .testTag(UserSelectionFieldTestTags.INPUT_USERNAME),
           singleLine = true)
 
       DropdownMenu(

--- a/app/src/main/java/com/android/ootd/ui/theme/Theme.kt
+++ b/app/src/main/java/com/android/ootd/ui/theme/Theme.kt
@@ -5,8 +5,6 @@ import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
@@ -42,7 +40,7 @@ fun OOTDTheme(
       when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
           val context = LocalContext.current
-          if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+          if (darkTheme) DarkColorScheme else LightColorScheme
         }
         darkTheme -> DarkColorScheme
         else -> LightColorScheme

--- a/app/src/main/java/com/android/ootd/ui/theme/Type.kt
+++ b/app/src/main/java/com/android/ootd/ui/theme/Type.kt
@@ -24,4 +24,6 @@ val Typography =
             TextStyle(fontFamily = Bodoni, fontWeight = FontWeight.Normal, fontSize = 20.sp),
         // body
         bodySmall =
-            TextStyle(fontFamily = Bodoni, fontWeight = FontWeight.Normal, fontSize = 13.sp))
+            TextStyle(fontFamily = Bodoni, fontWeight = FontWeight.Normal, fontSize = 13.sp),
+        headlineLarge =
+            TextStyle(fontFamily = Bodoni, fontWeight = FontWeight.Normal, fontSize = 64.sp))


### PR DESCRIPTION
# Summary
Changed UI to be in accordance to the Figma design.


# What
<!-- Briefly list what changed, grouped by area below. Remove any subsection that doesn't apply. -->

- UI
  - I updated the components related to the search screen: UserProfileCard, UserSearchScreen and the UserSelectionField to have the right proportions.
  - I also updated how we import the color for the OOTDTheme, this enabled the colors to be the ones we actually got from Figma.
  - I also added a new font style because I did not have anything that was 64.sp in size.


# Why
If the design is more close to the Figma design, we are sure that our vision is being perfectly transposed onto to the phone for the user.

# Manual testing

For manual testing, I suggest the following changes because the preview for the search screen will not render the dropdown correctly, however, it works when running the main app:

- First, go into MainActivity.kt and replace the OOTDApp with UserSearchScreen(UserSearchViewModel(overrideUser = true)).
- Then, go into the UserSearchViewModel and give testingUsername the value "c0e59e47-b274-446d-b12a-96c77e75bca3". For context, this is just a user that is presently in the database. 

Now you should be able to open the app and test the functionality of the screen.

# Videos of testing

For a demo of how everything should work:

https://github.com/user-attachments/assets/ef223a0c-ffcd-4f26-a2cb-0a5843b171a1

Closes #105 