### PR TITLE
feat(ci): Add CI create signed APK on realse

### DIFF
--- a/.github/scripts/setup-android-signing.sh
+++ b/.github/scripts/setup-android-signing.sh
@@ -4,20 +4,11 @@ set -e
 # Create the .ci-secrets directory
 mkdir -p "$GITHUB_WORKSPACE/.ci-secrets"
 
-# Decode the keystore from base64 and save it
+# Decode the keystore from base64 and save it locally
 if [ -n "$ANDROID_KEYSTORE_BASE64" ]; then
   echo "Decoding Android keystore..."
   echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$GITHUB_WORKSPACE/.ci-secrets/release.keystore"
   echo "✓ Keystore decoded successfully"
 else
   echo "Warning: ANDROID_KEYSTORE_BASE64 not set"
-fi
-
-# Decode google-services.json if provided (optional)
-if [ -n "$PLAY_SERVICE_JSON_BASE64" ]; then
-  echo "Decoding google-services.json..."
-  echo "$PLAY_SERVICE_JSON_BASE64" | base64 -d > "$GITHUB_WORKSPACE/app/google-services.json"
-  echo "✓ google-services.json decoded successfully"
-else
-  echo "Note: PLAY_SERVICE_JSON_BASE64 not set (optional)"
 fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,15 @@ jobs:
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v2
+      
+      - name: CI Banner                            
+        run: |
+          echo '             _      _    ___  ______ _   __'
+          echo '            | |    | |  / _ \ | ___ \ | / /'
+          echo '  ___   ___ | |_ __| | / /_\ \| |_/ / |/ / '
+          echo ' / _ \ / _ \| __/ _` | |  _  ||  __/|    \'
+          echo '| (_) | (_) | || (_| | | | | || |   | |\  \'
+          echo ' \___/ \___/ \__\__,_| \_| |_/\_|   \_| \_/'
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -33,7 +42,6 @@ jobs:
         shell: bash
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.GOOGLE_SERVICES }}
-          PLAY_SERVICE_JSON_BASE64: ${{ secrets.PLAY_SERVICE_JSON_BASE64 }}
         run: |
           bash .github/scripts/setup-android-signing.sh
           echo "ANDROID_KEYSTORE_PATH=$GITHUB_WORKSPACE/.ci-secrets/release.keystore" >> $GITHUB_ENV

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,11 +36,18 @@ android {
 
     signingConfigs {
         create("release") {
-            // CI/CD signing configuration
-            storeFile = System.getenv("ANDROID_KEYSTORE_PATH")?.let { file(it) }
-            storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
-            keyAlias = System.getenv("ANDROID_KEY_ALIAS")
-            keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+            // CI signing config
+            val keystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
+            val keystorePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+            val keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+            val keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+            
+            if (keystorePath != null && keystorePassword != null && keyAlias != null && keyPassword != null) {
+                storeFile = file(keystorePath)
+                storePassword = keystorePassword
+                this.keyAlias = keyAlias
+                this.keyPassword = keyPassword
+            }
         }
     }
 
@@ -51,7 +58,11 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release")
+
+            // Only use release signing config for the CI env
+            if (System.getenv("ANDROID_KEYSTORE_PATH") != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
 
         debug {


### PR DESCRIPTION
# Summary
Added a new CI that, on release should create a new signed APK for a specific KEY.
This pipeline also creates an AAB if we want to get our apps to the play store. If we want to disable this build we can do so in the CI. 

Each information, such as the specific key and build version are kept in `Github SECRETS`. 

P.S. : if you need to add a new key, ask me and i will create you a key with the right access

# What
New Ci that build a new signed APK and signed AAB and puts them in the Github artefacts.

# Why
For each Milestone we need to have a working APK, it's easier if we have a pipeline that does that automatically rather that doing it by hand each time. But we can still do it by hand as a fallback if this method dont work. I tried it locally with the current version of main, and it worked 🔥 .

A later feature to add would be to have a checksum file to verify that the file is not corrupted. 