### PR TITLE
Fix: Registration process upon first login

### DIFF
--- a/app/src/main/java/com/android/ootd/ui/authentication/SplashScreen.kt
+++ b/app/src/main/java/com/android/ootd/ui/authentication/SplashScreen.kt
@@ -77,7 +77,7 @@ fun SplashScreen(
 
   LaunchedEffect(Unit) {
     delay(SPLASH_TIMEOUT)
-    viewModel.onAppStart(onSignedIn, onNotSignedIn)
+    viewModel.onAppStart(onSignedIn = onSignedIn, onNotSignedIn = onNotSignedIn)
   }
 }
 

--- a/app/src/main/java/com/android/ootd/ui/authentication/SplashViewModel.kt
+++ b/app/src/main/java/com/android/ootd/ui/authentication/SplashViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.ootd.model.authentication.AccountService
 import com.android.ootd.model.authentication.AccountServiceFirebase
+import com.android.ootd.model.user.UserRepository
+import com.android.ootd.model.user.UserRepositoryProvider
 import kotlinx.coroutines.launch
 
 /**
@@ -18,11 +20,13 @@ class SplashViewModel(private val accountService: AccountService = AccountServic
   /**
    * Checks authentication status and invokes the appropriate callback.
    *
+   * @param
    * @param onSignedIn invoked if a user is signed in.Should navigate to the feed.
    * @param onNotSignedIn invoked if no user is signed in or an error occurs. Should navigate to
    *   sign-in.
    */
   fun onAppStart(
+      userRepository: UserRepository = UserRepositoryProvider.repository,
       onSignedIn: () -> Unit = {},
       onNotSignedIn: () -> Unit = {},
   ) {
@@ -35,7 +39,16 @@ class SplashViewModel(private val accountService: AccountService = AccountServic
           }
 
       if (hasUser) {
-        onSignedIn()
+        try {
+          val userExists = userRepository.userExists(accountService.currentUserId)
+          if (userExists) {
+            onSignedIn()
+          } else {
+            onNotSignedIn()
+          }
+        } catch (e: Exception) {
+          onNotSignedIn()
+        }
       } else {
         onNotSignedIn()
       }


### PR DESCRIPTION
# Summary
QuickFix for the registering process, which did not work properly 


# What
The viewModel now checks if the user has a username, if not he sends him to registerScreen, else to the feed. This makes the registering process now robust and foolproof

- ViewModel
  - Added checks for username with his userID
- Tests
  - Integration tests updated to test correct implementation of navigation


# Why
Bug that had to be fixed for proper app usage

# Checklist
- [x] Tests: added or updated (unit/instrumented/automation) as appropriate
- [x] Manual verification: app run and basic flows checked (list steps in "What")
