### PR TITLE
feat(search_screen): Finish adding navigation

### DIFF
--- a/app/src/androidTest/java/com/android/ootd/ui/searchscreen/UserSearchScreenTest.kt
+++ b/app/src/androidTest/java/com/android/ootd/ui/searchscreen/UserSearchScreenTest.kt
@@ -1,5 +1,7 @@
 package com.android.ootd.ui.searchscreen
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
@@ -10,7 +12,19 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
+import androidx.navigation.compose.rememberNavController
 import com.android.ootd.model.user.UserRepositoryInMemory
+import com.android.ootd.ui.feed.FeedScreen
+import com.android.ootd.ui.feed.FeedScreenTestTags
+import com.android.ootd.ui.feed.FeedScreenTestTags.NAVIGATE_TO_SEARCH_SCREEN
+import com.android.ootd.ui.navigation.NavigationActions
+import com.android.ootd.ui.navigation.Screen
+import com.android.ootd.ui.search.SearchScreenTestTags
+import com.android.ootd.ui.search.SearchScreenTestTags.SEARCH_SCREEN
 import com.android.ootd.ui.search.UserProfileCardTestTags
 import com.android.ootd.ui.search.UserSearchScreen
 import com.android.ootd.ui.search.UserSearchScreenPreview
@@ -27,6 +41,28 @@ import org.junit.Test
 
 class UserSearchScreenTest : FirestoreTest() {
   @get:Rule val composeTestRule = createComposeRule()
+  private lateinit var navController: NavHostController
+  private lateinit var navigationActions: NavigationActions
+
+  @Composable
+  private fun SetupTestNavigationHost() {
+    navController = rememberNavController()
+    navigationActions = NavigationActions(navController)
+
+    NavHost(navController = navController, startDestination = Screen.Feed.route) {
+      navigation(startDestination = Screen.Feed.route, route = Screen.Feed.name) {
+        composable(Screen.Feed.route) {
+          FeedScreen(
+              onAddPostClick = { /* TODO: handle add post */}, // this will go to AddItemScreen
+              onSearchClick = { navigationActions.navigateTo(Screen.SearchScreen) },
+              onProfileClick = { /* TODO: show user profile page */})
+        }
+        composable(Screen.SearchScreen.route) {
+          UserSearchScreen(onBack = { navigationActions.goBack() })
+        }
+      }
+    }
+  }
 
   @Test
   fun testGeneralSearch() {
@@ -89,6 +125,20 @@ class UserSearchScreenTest : FirestoreTest() {
   }
 
   @Test
+  fun searchScreenNavigation() {
+    composeTestRule.setContent { SetupTestNavigationHost() }
+    composeTestRule.onNodeWithTag(NAVIGATE_TO_SEARCH_SCREEN).performClick()
+
+    composeTestRule.onNodeWithTag(SEARCH_SCREEN).assertIsDisplayed()
+
+    composeTestRule
+        .onNodeWithTag(SearchScreenTestTags.GO_BACK_BUTTON)
+        .assertIsDisplayed()
+        .performClick()
+    composeTestRule.onNodeWithTag(FeedScreenTestTags.SCREEN).assertIsDisplayed()
+  }
+
+  @Test
   fun testSearchWithNoResults() {
     composeTestRule.setContent { UserSearchScreenPreview() }
 
@@ -120,7 +170,7 @@ class UserSearchScreenTest : FirestoreTest() {
     val mockViewModel =
         UserSearchViewModel(userRepository = UserRepositoryInMemory(), overrideUser = false)
 
-    composeTestRule.setContent { UserSearchScreen(viewModel = mockViewModel) }
+    composeTestRule.setContent { UserSearchScreen(viewModel = mockViewModel, onBack = {}) }
     val secondUsername = UserRepositoryInMemory().nameList[1]
     composeTestRule
         .onNodeWithTag(UserSelectionFieldTestTags.INPUT_USERNAME)
@@ -158,7 +208,7 @@ class UserSearchScreenTest : FirestoreTest() {
     val mockViewModel =
         UserSearchViewModel(userRepository = UserRepositoryInMemory(), overrideUser = false)
 
-    composeTestRule.setContent { UserSearchScreen(viewModel = mockViewModel) }
+    composeTestRule.setContent { UserSearchScreen(viewModel = mockViewModel, onBack = {}) }
     val secondUsername = UserRepositoryInMemory().nameList[1]
     composeTestRule
         .onNodeWithTag(UserSelectionFieldTestTags.INPUT_USERNAME)

--- a/app/src/main/java/com/android/ootd/MainActivity.kt
+++ b/app/src/main/java/com/android/ootd/MainActivity.kt
@@ -25,6 +25,7 @@ import com.android.ootd.ui.navigation.NavigationActions
 import com.android.ootd.ui.navigation.Screen
 import com.android.ootd.ui.post.EditItemsScreen
 import com.android.ootd.ui.register.RegisterScreen
+import com.android.ootd.ui.search.UserSearchScreen
 import com.android.ootd.ui.theme.OOTDTheme
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage
@@ -77,6 +78,9 @@ fun OOTDApp(
       composable(Screen.RegisterUsername.route) {
         RegisterScreen(onRegister = { navigationActions.navigateTo(Screen.Feed) })
       }
+      composable(Screen.SearchScreen.route) {
+        UserSearchScreen(onBack = { navigationActions.goBack() })
+      }
     }
 
     // 2. SignIn route (top-level, for unauthenticated users)
@@ -94,13 +98,11 @@ fun OOTDApp(
       composable(Screen.Feed.route) {
         FeedScreen(
             onAddPostClick = { /* TODO: handle add post */}, // this will go to AddItemScreen
-            onSearchClick = { /* TODO: show search profile page */},
+            onSearchClick = { navigationActions.navigateTo(Screen.SearchScreen) },
             onProfileClick = { /* TODO: show user profile page */})
       }
 
-      /* TODO: add navigation to ProfileScreen and SearchScreen */
-      // Navigation to Search screen is not yet implemented
-
+      /* TODO: add navigation to ProfileScreen*/
       // Navigation to User Profile screen is not yet implemented
 
       composable(

--- a/app/src/main/java/com/android/ootd/ui/feed/FeedScreen.kt
+++ b/app/src/main/java/com/android/ootd/ui/feed/FeedScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.ootd.model.OutfitPost
+import com.android.ootd.ui.feed.FeedScreenTestTags.NAVIGATE_TO_SEARCH_SCREEN
 
 object FeedScreenTestTags {
   const val SCREEN = "feedScreen"
@@ -21,6 +22,7 @@ object FeedScreenTestTags {
   const val LOCKED_MESSAGE = "feedLockedMessage"
   const val ADD_POST_FAB = "addPostFab"
   const val FEED_LIST = "feedList"
+  const val NAVIGATE_TO_SEARCH_SCREEN = "navigateToSearchScreen"
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -48,12 +50,13 @@ fun FeedScreen(
                           fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary))
             },
             navigationIcon = {
-              IconButton(onClick = onSearchClick) {
-                Icon(
-                    imageVector = Icons.Default.Search,
-                    contentDescription = "Search",
-                    tint = MaterialTheme.colorScheme.tertiary)
-              }
+              IconButton(
+                  onClick = onSearchClick, modifier = Modifier.testTag(NAVIGATE_TO_SEARCH_SCREEN)) {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = "Search",
+                        tint = MaterialTheme.colorScheme.tertiary)
+                  }
             },
             actions = {
               // TODO: replace this icon with user profile avatar once implemented

--- a/app/src/main/java/com/android/ootd/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/ootd/ui/navigation/NavigationActions.kt
@@ -37,6 +37,7 @@ sealed class Screen(
   object Feed : Screen(route = "feed", name = "Feed", isTopLevelDestination = true)
 
   // TODO: add routes for Search Screen and Profile Screen
+  object SearchScreen : Screen(route = "search", name = "Search", isTopLevelDestination = false)
 
   data class EditItem(val itemUid: String) :
       Screen(route = "editItem/${itemUid}", name = "Edit Item") {

--- a/app/src/main/java/com/android/ootd/ui/search/UserSearchScreen.kt
+++ b/app/src/main/java/com/android/ootd/ui/search/UserSearchScreen.kt
@@ -8,25 +8,34 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.ootd.model.user.UserRepositoryInMemory
 import com.android.ootd.ui.theme.OOTDTheme
 
+object SearchScreenTestTags {
+  const val SEARCH_SCREEN = "searchScreen"
+  const val GO_BACK_BUTTON = "goBackButton"
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun UserSearchScreen(viewModel: UserSearchViewModel = viewModel()) {
+fun UserSearchScreen(viewModel: UserSearchViewModel = viewModel(), onBack: () -> Unit) {
   val uiState by viewModel.uiState.collectAsState()
 
   Column(
       modifier =
           Modifier.fillMaxSize()
               .background(MaterialTheme.colorScheme.background)
-              .padding(vertical = 32.dp, horizontal = 20.dp)) {
+              .padding(vertical = 32.dp, horizontal = 20.dp)
+              .testTag(SearchScreenTestTags.SEARCH_SCREEN)) {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
           IconButton(
-              modifier = Modifier.width(48.dp).height(48.dp), onClick = { /* Handle back */}) {
+              modifier =
+                  Modifier.width(48.dp).height(48.dp).testTag(SearchScreenTestTags.GO_BACK_BUTTON),
+              onClick = onBack) {
                 Icon(
                     modifier = Modifier.width(48.dp).height(48.dp),
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -75,6 +84,6 @@ fun UserSearchScreenPreview() {
   OOTDTheme {
     val mockViewModel =
         UserSearchViewModel(userRepository = UserRepositoryInMemory(), overrideUser = true)
-    UserSearchScreen(viewModel = mockViewModel)
+    UserSearchScreen(viewModel = mockViewModel, onBack = {})
   }
 }


### PR DESCRIPTION
# Summary
Integrate the search screen in the navigation controller.


# What

- ViewModel
  - Passed the functions for the navigation in the necessary places for the search screen button and the go back button from the search screen.
- Tests
  - Added a test for navigation between the two pages. It creates a custom navigation controller such that I do not recreate the whole app from scratch.


# Why
With this change the user will be able to access the search screen. 


# Screenshots / Videos

https://github.com/user-attachments/assets/57896505-bb04-46c1-9fc9-15db46ba8f2b

# Manual testing

For manual testing, you can run the app, login with your email and then just check that by pressing the search button you get the same effect as in the video above.

Closes #71 
