### PR TITLE
fix(proguard): Fix proguard rules because they obfuscate firebase dat…

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,20 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+# Keep all classes annotated with @Keep
+-keep @androidx.annotation.Keep class * { *; }
+
+# Firebase Firestore
+-keepattributes Signature
+-keepattributes *Annotation*
+-keepattributes EnclosingMethod
+-keepattributes InnerClasses
+
+# Keep Firestore classes
+-keep class com.google.firebase.firestore.** { *; }
+-keep class com.google.android.gms.** { *; }
+
+# Keep data class constructors
+-keepclassmembers class * {
+    public <init>();
+}

--- a/app/src/main/java/com/android/ootd/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/ootd/model/user/UserRepositoryFirestore.kt
@@ -2,6 +2,7 @@ package com.android.ootd.model.user
 
 import android.net.Uri
 import android.util.Log
+import androidx.annotation.Keep
 import androidx.core.net.toUri
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FieldValue
@@ -15,6 +16,7 @@ const val USER_COLLECTION_PATH = "users"
 // Custom exception for taken username scenario
 class TakenUsernameException(message: String) : Exception(message)
 
+@Keep
 private data class UserDto(
     val uid: String = "",
     val username: String = "",


### PR DESCRIPTION
Due to the fact that proguard is obfuscating code, the name of the dataclasses are also being obfuscated and the implicit serialization for firebase does not work anymore. This would make the search screen fail when trying to access the user repository.

The exact error is the following:

10-17 01:39:11.258 15104 15104 E UserRepositoryFirestore: Error transforming document v8dYB5iAEaew2mHCzYKHN8aqPyd2: Could not deserialize object. Class h6.c does not define a no-argument constructor. If you are using ProGuard, make sure these constructors are not stripped
10-17 01:39:11.258 15104 15104 E UserRepositoryFirestore: java.lang.RuntimeException: Could not deserialize object. Class h6.c does not define a no-argument constructor. If you are using ProGuard, make sure these constructors are not stripped