### PR TITLE
refactor(test): update outfit post repository test

### DIFF
--- a/app/src/androidTest/java/com/android/ootd/utils/BaseTest.kt
+++ b/app/src/androidTest/java/com/android/ootd/utils/BaseTest.kt
@@ -1,7 +1,9 @@
 package com.android.ootd.utils
 
+import com.android.ootd.model.post.OutfitPostRepositoryFirestore
 import com.android.ootd.model.user.User
 import com.android.ootd.model.user.UserRepository
+import com.android.ootd.model.user.UserRepositoryFirestore
 import com.android.ootd.model.user.UserRepositoryProvider
 import com.google.firebase.auth.FirebaseUser
 import org.junit.After
@@ -16,11 +18,10 @@ const val UI_WAIT_TIMEOUT = 5_000L
  */
 abstract class BaseTest() {
 
-  abstract fun createInitializedRepository(): UserRepository
-
   val repository: UserRepository
     get() = UserRepositoryProvider.repository
 
+  lateinit var outfitPostRepository: OutfitPostRepositoryFirestore
   val currentUser: FirebaseUser
     get() {
       return FirebaseEmulator.auth.currentUser!!
@@ -36,7 +37,9 @@ abstract class BaseTest() {
 
   @Before
   open fun setUp() {
-    UserRepositoryProvider.repository = createInitializedRepository()
+    UserRepositoryProvider.repository = UserRepositoryFirestore(FirebaseEmulator.firestore)
+    outfitPostRepository =
+        OutfitPostRepositoryFirestore(FirebaseEmulator.firestore, FirebaseEmulator.storage)
   }
 
   @After

--- a/app/src/androidTest/java/com/android/ootd/utils/FirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/ootd/utils/FirestoreTest.kt
@@ -1,9 +1,6 @@
 package com.android.ootd.utils
 
-import android.util.Log
 import com.android.ootd.model.user.USER_COLLECTION_PATH
-import com.android.ootd.model.user.UserRepository
-import com.android.ootd.model.user.UserRepositoryFirestore
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -27,24 +24,13 @@ open class FirestoreTest() : BaseTest() {
     }
   }
 
-  override fun createInitializedRepository(): UserRepository {
-    return UserRepositoryFirestore(db = FirebaseEmulator.firestore)
-  }
-
   @Before
   override fun setUp() {
     super.setUp()
 
     runTest {
+      FirebaseEmulator.clearFirestoreEmulator()
       FirebaseEmulator.auth.signInAnonymously().await()
-      val userCount = getUserCount()
-      if (userCount > 0) {
-        Log.w(
-            "FirebaseEmulatedTest",
-            "Warning: Test collection is not empty at the beginning of the test, count: $userCount",
-        )
-        clearTestCollection()
-      }
     }
   }
 


### PR DESCRIPTION
# Summary
Changed the tests for the outfit post repository to follow the testing guidelines.

# What
The class OutfitPostRepositoryFirestoreTest, FirestoreTest  and BaseTest were modified in order for the outfit post repository to be initialised in only one place.

- Tests
  - Outfit post repository tests were modified to use the specific outfit post repository now initialized in BaseTest.


# Why
This is related to issue https://github.com/swent-Team01/OOTD/issues/126 and it helps with removing code duplication and with the building of future tests. New people that want to create tests will just use the repositories that are already initialized in BaseTest by inheriting the FirestoreTest class.

For the guidelines check this link: [Testing guidelines](https://github.com/swent-Team01/OOTD/wiki/Testing-using-repositories-guidelines)
