### PR TITLE
hotfix(ci): sonar not getting instrumented test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,14 @@ jobs:
           disable-animations: true
           script: ./gradlew connectedCheck --parallel --build-cache
 
+      - name: Upload Instrumentation Test Coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: instrumentation-coverage
+          path: app/build/outputs/code_coverage/
+          retention-days: 1
+
   # Job 5: Unit Tests (depends on compile-debug)
   unit-tests:
     name: Unit Tests
@@ -274,6 +282,14 @@ jobs:
       - name: Run Unit Tests
         run: ./gradlew check --parallel --build-cache
 
+      - name: Upload Unit Test Coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unit-test-coverage
+          path: app/build/outputs/unit_test_code_coverage/
+          retention-days: 1
+
       - name: Firestore Security Rules tests
         run: |
           if [ ! -e "firebase.json" ]; then
@@ -300,11 +316,11 @@ jobs:
             echo "Warning: Firestore rules file not found in firebase/firestore"
           fi
 
-  # Job 6: Coverage Report (depends on unit-tests)
+  # Job 6: Coverage Report (depends on both unit-tests and android-instrumentation-tests)
   coverage-report:
     name: Coverage Report
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: unit-tests
+    needs: [unit-tests, android-instrumentation-tests]
     
     steps:
       - name: Checkout
@@ -346,6 +362,18 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
+
+      - name: Download Unit Test Coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-test-coverage
+          path: app/build/outputs/unit_test_code_coverage/
+
+      - name: Download Instrumentation Test Coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: instrumentation-coverage
+          path: app/build/outputs/code_coverage/
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools


### PR DESCRIPTION
# Summary
Fix the issue were the Coverage didn't take in account the Instrumented tests

# What
Made it so the coverage task has to wait for the Instrumented tests and Unit test to finish until starting the Coverage report 