### PR TITLE
fix(debug_apk): Remove signing with release keys

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -40,14 +40,6 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Decode signing and optional files
-        shell: bash
-        env:
-          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-        run: |
-          bash .github/scripts/setup-android-signing.sh
-          echo "ANDROID_KEYSTORE_PATH=$GITHUB_WORKSPACE/.ci-secrets/release.keystore" >> $GITHUB_ENV
-
       - name: Decode secrets for FireBase
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}


### PR DESCRIPTION
<!--
Compact Pull Request template for the OOTD repository.
Sections: Summary, What, Why, Screenshots/Videos, Checklist.
Authors should keep entries short and remove sections that don't apply.
-->

# Summary
Changed github workflow to remove signing with release key.


# What
Changed github workflow to remove signing with release key.


# Why
Signing with the wrong key prevents the user from signing in.