### PR TITLE
fix(FeedViewModel): initialise isLoading state by true to avoid flick…

### DIFF
--- a/app/src/main/java/com/android/ootd/ui/feed/FeedViewModel.kt
+++ b/app/src/main/java/com/android/ootd/ui/feed/FeedViewModel.kt
@@ -108,6 +108,11 @@ open class FeedViewModel(
     _uiState.value = _uiState.value.copy(currentAccount = account)
   }
 
+  /**
+   * Sets the error message in the UI state
+   *
+   * @param message The error message to set in the UI state.
+   */
   fun setErrorMessage(message: String?) {
     _uiState.value = _uiState.value.copy(errorMessage = message)
   }


### PR DESCRIPTION
# Summary
Fixes a UI flicker on the Feed screen caused by `isLoading` initializing as `false` and not being updated at the start of data refresh.  

# What
- **FeedViewModel**
  - Initialized `FeedUiState` with `isLoading = true` to start in a loading state.

# Why
Previously, when entering the Feed screen, the app briefly displayed an empty or unlocked feed before the loading overlay appeared.  
This happened because `isLoading` was initially `false`, so the UI rendered before data was fetched.  
Starting in a loading state and explicitly setting `isLoading = true` before refresh removes that flicker and ensures a stable, polished loading experience.

# Checklist
- [x] Verified feed no longer flickers on navigation or refresh  
- [x] Confirmed loading overlay displays immediately on first load and during data refresh  
