### PR TITLE
Refactor: Added forgotten brand field on `SeeFitItemDialog`

### DIFF
--- a/app/src/androidTest/java/com/android/ootd/ui/feed/SeeFitScreenTest.kt
+++ b/app/src/androidTest/java/com/android/ootd/ui/feed/SeeFitScreenTest.kt
@@ -189,6 +189,7 @@ class SeeFitScreenTest {
     composeTestRule.onNodeWithTag(SeeFitScreenTestTags.ITEM_LINK).assertIsDisplayed()
     composeTestRule.onNodeWithTag(SeeFitScreenTestTags.ITEM_PRICE).assertIsDisplayed()
     composeTestRule.onNodeWithTag(SeeFitScreenTestTags.ITEM_MATERIAL).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SeeFitScreenTestTags.ITEM_BRAND).assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/android/ootd/ui/feed/SeeFitItemDialog.kt
+++ b/app/src/main/java/com/android/ootd/ui/feed/SeeFitItemDialog.kt
@@ -83,6 +83,14 @@ fun SeeItemDetailsDialog(
                     textAlign = TextAlign.Center,
                     modifier = Modifier.testTag(SeeFitScreenTestTags.ITEM_TYPE))
 
+                Text(
+                    text = item.brand ?: "Item Brand",
+                    style =
+                        MaterialTheme.typography.bodyLarge.copy(
+                            color = MaterialTheme.colorScheme.onSurfaceVariant),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.testTag(SeeFitScreenTestTags.ITEM_BRAND))
+
                 item.price?.let {
                   Text(
                       text = "CHF ${String.format("%.2f", it)}",


### PR DESCRIPTION
<!--
Compact Pull Request template for the OOTD repository.
Sections: Summary, What, Why, Screenshots/Videos, Checklist.
Authors should keep entries short and remove sections that don't apply.
-->

# Summary
<!-- Summary of the change. -->
This PR introduces a forgotten field on the item dialog. 

# What
<!-- Briefly list what changed, grouped by area below. Remove any subsection that doesn't apply. -->

- UI
  -  `SeeFitItemDialog` updated 
      -  Added forgotten brand field to show on the item dialog. 
- Tests
  - UI tests updated : In `itemCardShowsItems_itemDialogDisplaysItemDetails_onClick` checks displaying of the brand field.


# Why
<!-- Motivation, links to issues, and any design decisions or trade-offs. -->
I forgot to add brand field on item dialog. We need this field so that other users can see and know where the item is coming from. 

# Screenshots / Videos
<!-- Optional: add screenshots or animated GIFs to help reviewers. -->


# Checklist
- [x] Tests: UI test is updated.
- [x] Manual verification: brand field is displayed on the item dialog. 

<!-- Remove any checklist items that don't apply to this PR -->
