### PR TITLE
Fix: Bug upload image from gallery 

### DIFF
--- a/app/src/main/java/com/android/ootd/model/items/FirebaseImageUploader.kt
+++ b/app/src/main/java/com/android/ootd/model/items/FirebaseImageUploader.kt
@@ -17,7 +17,7 @@ object FirebaseImageUploader {
   private const val TAG = "FirebaseImageUploader"
 
   // Timeout duration for upload operations to Firebase Storage
-  private const val UPLOAD_TIMEOUT_MS = 1000L // 1 seconds
+  private const val UPLOAD_TIMEOUT_MS = 2000L // 2 seconds
 
   private val storage by lazy {
     try {
@@ -64,9 +64,10 @@ object FirebaseImageUploader {
     // If local file exists, keep offline URI; else return empty to signal invalid selection
     return try {
       val isFile = localUri.scheme == "file"
+      val isContent = localUri.scheme == "content"
       val path = localUri.path
       val fileExists = isFile && path != null && java.io.File(path).exists()
-      if (fileExists) ImageData(imageId = fileName, imageUrl = localUri.toString())
+      if (fileExists || isContent) ImageData(imageId = fileName, imageUrl = localUri.toString())
       else ImageData("", "")
     } catch (_: Exception) {
       ImageData("", "")


### PR DESCRIPTION
# Summary
This PR fixes a bug were you could not upload images from your gallery as their specific URI were not accepted.

>[!WARNING]
> At first, this PR was supposed to fix both the bug when uploading an image from the gallery and the bug with uploaded pictures offline. As the second bug was not successfully corrected, I thought it was better if I split the PR so this one is fixed before tomorrow’s meeting!

# What
- Increase the `UPLOAD_TIMEOUT_MS` to 2000ms ( before it was 1 seconds) to reduce false positives on decent connections as @asunluer suggested it.
- Update `fallbackImageData` to accept `content:// URIs`. This ensures that if the upload times out (or you are offline), the item is still created and cached locally using the local image URI. This fixed the bug @asunluer pointed out in the last meeting 👍🏼 .


# Why
There was a bug with the timeout and image function not accepting image from the gallery. This fix is necessary as it was a breaking feature.

# Screenshots / Videos
Example of the fix workflow of adding an image from gallery when creating an item.

[Screen_recording_20251127_195758.webm](https://github.com/user-attachments/assets/ef576b44-08e5-4e11-8210-8b7aae550f38)


# Checklist
- [ ] Tests: added or updated (unit/instrumented/automation) as appropriate
- [x] Documentation: README/usage/docs updated where relevant
- [x] Manual verification: app run and basic flows checked (list steps in "What")
