### PR TITLE
Feat: update java versions from 17 to 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
 
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
@@ -67,7 +67,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
 
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
@@ -104,7 +104,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
 
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
@@ -141,7 +141,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
 
       - name: Setup NodeJS
         uses: actions/setup-node@v4
@@ -265,7 +265,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
 
       - name: Setup NodeJS
         uses: actions/setup-node@v4
@@ -356,7 +356,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
 
       - name: Setup NodeJS
         uses: actions/setup-node@v4


### PR DESCRIPTION
# Summary
Updated Java version from 17 to 21 in CI workflow to fix Firebase emulator startup failures

# What
  - Updated Java version from 17 to 21 across all 6 CI jobs (format-check, assemble-and-lint, compile-debug, android-instrumentation-tests, unit-tests, coverage-report)

# Why
Firebase emulators require Java 21 in recent versions. The CI tests were failing because Java 17 is no longer sufficient for the emulator suite to start properly.

