### PR TITLE
 Add friendCount to the view user page

### DIFF
--- a/app/src/androidTest/java/com/android/ootd/end2end/fourthEnd2endTest.kt
+++ b/app/src/androidTest/java/com/android/ootd/end2end/fourthEnd2endTest.kt
@@ -149,7 +149,7 @@ class FourthEnd2EndTest : FirestoreTest() {
         username = "user_2",
         dateOfBirth = testDateofBirth,
         acceptBetaScreen = false)
-
+    val user2UID = FirebaseEmulator.auth.currentUser?.uid ?: ""
     // STEP 5: Create a post with one item for the second user
     Log.d(TAG, "STEP5: add post with location for user_2")
     addPostWithOneItem(composeTestRule, addLocation = true)
@@ -169,6 +169,12 @@ class FourthEnd2EndTest : FirestoreTest() {
     // STEP 8: Accept follow request from second user from first user's account
     Log.d(TAG, "STEP8: accept follow request in notifications")
     openNotificationsScreenAndAcceptNotification(composeTestRule = composeTestRule)
+
+    val user1 = userRepository.getUser(FirebaseEmulator.auth.currentUser?.uid ?: "")
+    assert(user1.friendCount == 1)
+
+    val user2 = userRepository.getUser(user2UID)
+    assert(user2.friendCount == 1)
 
     // STEP 9: Check that both posts of the users appear in the first user's feed
     Log.d(TAG, "STEP9: check number of posts in feed for user_1")

--- a/app/src/main/java/com/android/ootd/model/account/AccountRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/ootd/model/account/AccountRepositoryFirestore.kt
@@ -262,20 +262,28 @@ class AccountRepositoryFirestore(
         throw NoSuchElementException("The user with id $friendID not found")
       }
 
-      val userRef = db.collection(ACCOUNT_COLLECTION_PATH).document(userID)
+      val currentUserAccountRef = db.collection(ACCOUNT_COLLECTION_PATH).document(userID)
 
       // With arrayUnion there can be no duplicates
       // https://firebase.google.com/docs/firestore/manage-data/add-data , Update elements in an
       // array section
 
       // Add the friendID in your friend list
-      userRef.update("friendUids", FieldValue.arrayUnion(friendID)).await()
+      currentUserAccountRef.update("friendUids", FieldValue.arrayUnion(friendID)).await()
+
+      // Increment the friend count
+      val currentUserRef = db.collection(USER_COLLECTION_PATH).document(userID)
+
+      currentUserRef.update("friendCount", FieldValue.increment(1)).await()
 
       // Add yourself to the friendID's friend list.
       // This works because we have not deleted the follow notification yet.
-      val friendRef = db.collection(ACCOUNT_COLLECTION_PATH).document(friendID)
+      val friendAccountRef = db.collection(ACCOUNT_COLLECTION_PATH).document(friendID)
+      val friendUserRef = db.collection(USER_COLLECTION_PATH).document(friendID)
+
       try {
-        friendRef.update("friendUids", FieldValue.arrayUnion(userID)).await()
+        friendAccountRef.update("friendUids", FieldValue.arrayUnion(userID)).await()
+        friendUserRef.update("friendCount", FieldValue.increment(1)).await()
         return true
       } catch (e: Exception) {
         // If we can't update their account (maybe we're not in their friend list),
@@ -300,13 +308,22 @@ class AccountRepositoryFirestore(
       }
 
       // Remove friendID from userID's friend list
-      val userRef = db.collection(ACCOUNT_COLLECTION_PATH).document(userID)
-      userRef.update("friendUids", FieldValue.arrayRemove(friendID)).await()
+      val currentUserAccountRef = db.collection(ACCOUNT_COLLECTION_PATH).document(userID)
+      currentUserAccountRef.update("friendUids", FieldValue.arrayRemove(friendID)).await()
+
+      // Decrement the friend count
+      val currentUserRef = db.collection(USER_COLLECTION_PATH).document(userID)
+
+      currentUserRef.update("friendCount", FieldValue.increment(-1)).await()
 
       // Remove userID from friendID's friend list (if they have us as a friend)
-      val friendRef = db.collection(ACCOUNT_COLLECTION_PATH).document(friendID)
+      val friendAccountRef = db.collection(ACCOUNT_COLLECTION_PATH).document(friendID)
+      val friendUserRef = db.collection(USER_COLLECTION_PATH).document(friendID)
+
       try {
-        friendRef.update("friendUids", FieldValue.arrayRemove(userID)).await()
+        // Need to decrement count before removing themselves from friend list.
+        friendUserRef.update("friendCount", FieldValue.increment(-1)).await()
+        friendAccountRef.update("friendUids", FieldValue.arrayRemove(userID)).await()
       } catch (e: Exception) {
         // If we can't update their account (maybe we're not in their friend list),
         // log it but don't fail the entire operation

--- a/app/src/main/java/com/android/ootd/model/user/User.kt
+++ b/app/src/main/java/com/android/ootd/model/user/User.kt
@@ -8,10 +8,12 @@ package com.android.ootd.model.user
  * @property ownerId unique identifier of the account owner for consistency across the app
  * @property username Display name of the user.
  * @property profilePicture URL path to the user's profile picture, empty string by default
+ * @property friendCount The friend count of the user.
  */
 data class User(
     val uid: String = "",
     val ownerId: String = "",
     val username: String = "",
-    val profilePicture: String = ""
+    val profilePicture: String = "",
+    val friendCount: Int = 0
 )

--- a/app/src/main/java/com/android/ootd/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/ootd/model/user/UserRepositoryFirestore.kt
@@ -21,7 +21,8 @@ private data class UserDto(
     val uid: String = "",
     val ownerId: String = "",
     val username: String = "",
-    val profilePicture: String = ""
+    val profilePicture: String = "",
+    val friendCount: Int = 0
 )
 
 private const val username_taken_exception = "Username already in use"
@@ -35,7 +36,8 @@ private fun User.toDto(): UserDto {
       uid = this.uid,
       ownerId = this.ownerId,
       username = this.username,
-      profilePicture = this.profilePicture)
+      profilePicture = this.profilePicture,
+      friendCount = this.friendCount)
 }
 
 private fun UserDto.toDomain(): User {
@@ -43,7 +45,8 @@ private fun UserDto.toDomain(): User {
       uid = this.uid,
       ownerId = this.ownerId,
       username = this.username,
-      profilePicture = this.profilePicture)
+      profilePicture = this.profilePicture,
+      friendCount = this.friendCount)
 }
 
 class UserRepositoryFirestore(private val db: FirebaseFirestore) : UserRepository {

--- a/app/src/main/java/com/android/ootd/ui/account/ViewUserViewModel.kt
+++ b/app/src/main/java/com/android/ootd/ui/account/ViewUserViewModel.kt
@@ -112,6 +112,7 @@ class ViewUserViewModel(
           it.copy(
               username = friend.username,
               friendId = friendId,
+              friendCount = friend.friendCount,
               hasRequestPending = isRequestPending,
               profilePicture = friend.profilePicture,
               friendPosts = friendPosts,
@@ -168,7 +169,9 @@ class ViewUserViewModel(
         if (_uiState.value.isFriend) {
           // Already followed → unfollow
           accountRepository.removeFriend(currentUserId, friendId)
-          _uiState.value = _uiState.value.copy(isFriend = false, errorMsg = null)
+          _uiState.value =
+              _uiState.value.copy(
+                  isFriend = false, errorMsg = null, friendCount = _uiState.value.friendCount - 1)
           return@launch
         }
 

--- a/firebase/firestore/firestore.rules
+++ b/firebase/firestore/firestore.rules
@@ -36,6 +36,18 @@ service cloud.firestore {
                        && resource.data.ownerId == request.auth.uid;
       allow delete: if isAuthed()
            && (resource == null || resource.data.ownerId == request.auth.uid);
+        // Non-owner can update ONLY to increment friendCount by 1 when adding themselves as friend
+        // This happens when they accept a follow request and add themselves to the account's friendUids
+        allow update: if isAuthed()
+                       && request.auth.uid != userId
+                       && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['friendCount'])
+                       && hasFollowNotification(userId);
+
+        // Non-owner can update ONLY to decrement friendCount by 1 when removing themselves as friend
+        allow update: if isAuthed()
+                         && request.auth.uid != userId
+                         && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['friendCount'])
+                         && isFriend(request.auth.uid, resource.data.ownerId);
     }
 
     // Notifications: read your own, write your own


### PR DESCRIPTION
<!--
Compact Pull Request template for the OOTD repository.
Sections: Summary, What, Why, Screenshots/Videos, Checklist.
Authors should keep entries short and remove sections that don't apply.
-->

# Summary
<!-- Summary of the change. -->
Add friendCount in the user repository as it is public to every user

# What
<!-- Briefly list what changed, grouped by area below. Remove any subsection that doesn't apply. -->

- ViewModel
  - In the viewUser page, the friendCount is taken from the user repository.
  - The friendCount is updated in the addFriend and removeFriend functions in the account repository.
- FirebaseRules
  - Created new rule for the user repository such that if another user wants to add a friend (by accepting the notification), they can modify the friendCount of the other user.
  - Created new rule for the user repository such that if another user removes a friend, they are able to change the friendCount of the other user.
- Tests
  - Added a check in the fourth end to end test to make sure that the friendCount is updated for both users when the friendship is accepted.

# Why
<!-- Motivation, links to issues, and any design decisions or trade-offs. -->
The friendCount was implemented in the viewUser page but was not functional before.

# Screenshots / Videos
<!-- Optional: add screenshots or animated GIFs to help reviewers. -->
