### PR TITLE
Enhancement : Align the comment and like icons properly

### DIFF
--- a/app/src/main/java/com/android/ootd/ui/feed/OutfitPostCard.kt
+++ b/app/src/main/java/com/android/ootd/ui/feed/OutfitPostCard.kt
@@ -142,16 +142,17 @@ private fun ProfileSection(post: OutfitPost, onProfileClick: (String) -> Unit = 
 @Composable
 private fun LikeRow(isLiked: Boolean, likeCount: Int, enabled: Boolean, onClick: () -> Unit) {
   Row(verticalAlignment = Alignment.CenterVertically) {
-    IconButton(
-        onClick = onClick,
-        enabled = enabled,
-        modifier = Modifier.testTag(OutfitPostCardTestTags.LIKE_BUTTON)) {
-          Icon(
-              imageVector = if (isLiked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
-              contentDescription = if (isLiked) "Liked" else "Unliked",
-              tint = if (isLiked) MaterialTheme.colorScheme.error else OnSecondaryContainer)
-        }
-    Spacer(modifier = Modifier.width(1.dp))
+    Icon(
+        imageVector = if (isLiked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+        contentDescription = if (isLiked) "Liked" else "Unliked",
+        tint = if (isLiked) MaterialTheme.colorScheme.error else OnSecondaryContainer,
+        modifier =
+            Modifier.size(26.dp)
+                .clickable(enabled = enabled, onClick = onClick)
+                .testTag(OutfitPostCardTestTags.LIKE_BUTTON))
+
+    Spacer(modifier = Modifier.width(4.dp))
+
     Text(
         text = likeCount.toString(),
         style = Typography.bodyMedium,
@@ -296,6 +297,7 @@ fun OutfitPostCard(
                 PostImage(post, isBlurred, modifier = clickableModifier)
                 PostLocation(post.location, onClick = { onLocationClick(post.location) })
                 DescriptionAndButton(post, isBlurred, onSeeFitClick)
+                Spacer(modifier = Modifier.height(8.dp))
                 // Reactions row
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -354,8 +356,11 @@ private fun CommentButton(commentCount: Int, enabled: Boolean, onClick: () -> Un
         Icon(
             imageVector = Icons.AutoMirrored.Outlined.Comment,
             contentDescription = "Comments",
-            tint = if (enabled) OnSecondaryContainer else Tertiary)
+            tint = if (enabled) OnSecondaryContainer else Tertiary,
+            modifier = Modifier.size(26.dp).offset(y = 1.dp))
+
         Spacer(modifier = Modifier.width(4.dp))
+
         Text(
             text = commentCount.toString(),
             style = Typography.bodyMedium,


### PR DESCRIPTION
<!--
Compact Pull Request template for the OOTD repository.
Sections: Summary, What, Why, Screenshots/Videos, Checklist.
Authors should keep entries short and remove sections that don't apply.
-->

# Summary
<!-- Summary of the change. -->
This PR introduces an enhancement of like and comments icons in the post card which is indicated in the [wiki](https://github.com/swent-Team01/OOTD/wiki/UX-Results-:-What-to-change#feed). 

# What
<!-- Briefly list what changed, grouped by area below. Remove any subsection that doesn't apply. -->

- UI
  - **OutfitPostCard** 
       - Modified the size of the two icons. 
       - Remove the `iconButton` which visually pushes the counting text away. Because of that the count looks dar from the heart 
       - Increment the spacer value between the like icon and its count to make the same as the comment. 
- ViewModel
  - There is no change of view model since this an enhancement regarding to UI
- Documentation
  - No additional documents are added neither updated
- Tests
  - The existing tests are already covers the behaviours that we want to check. 


# Why
<!-- Motivation, links to issues, and any design decisions or trade-offs. -->
The reason that modifications are made because these icons are not well aligned and were too separated between them which was damaging UI. To prevent this, this enhancement is applied. 

# Screenshots / Videos
<!-- Optional: add screenshots or animated GIFs to help reviewers. -->
Before 
<img width="303" height="489" alt="Screenshot 2025-12-14 at 23 59 05" src="https://github.com/user-attachments/assets/bbffdd85-4794-44b3-9f93-2a3637607e1d" />

After 
<img width="302" height="493" alt="Screenshot 2025-12-14 at 23 58 01" src="https://github.com/user-attachments/assets/20bfbcbe-cae2-4c65-8f80-14541fd25e7b" />


# Checklist
- [x] Manual verification: Run the app and see the icons in outfit card in the **Feed**.


<!-- Remove any checklist items that don't apply to this PR -->
